### PR TITLE
Add types to package.json exports - fixes #13

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "types": "dist/index.d.ts",
   "type": "module",
   "exports": {
-    ".": "./dist/index.js"
+    ".": "./dist/index.js",
+    "./types": "./dist/types.d.ts"
   },
   "files": [
     "dist"


### PR DESCRIPTION
There's currently no way to import from `types.d.ts`.

This change adds the ability to do the following in a `vite.config.ts` file:

```ts
import type { SitemapEntry } from '@qalisa/vike-plugin-sitemap/types';

/* ... */

const customEntries = [] as SitemapEntry[];
```